### PR TITLE
Add the Simulation ObjectID to all responses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Import the module:
 
 `const simConnect = require('msfs-simconnect-nodejs');`
 
+## Differences between MSFS SimConnect and node SimConnect
+
+Calls to `requestDataOnSimObject` and `requestDataOnSimObjectType` will return the simulation ObjectID for the object in the callback data object in addition to the requested Simulation Variables.
+
+ObjectID 1 is the user.
+
 ## Requirements
 * NodeJS 64 bit
 * Microsoft Visual Studio 2019 (Community)

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -186,6 +186,9 @@ void handleReceived_Data(Isolate *isolate, SIMCONNECT_RECV *pData, DWORD cbData)
 	Local<Object> result_list = Object::New(isolate);
 	int dataValueOffset = 0;
 
+	// always add the Object ID to the response payload
+	result_list->Set(String::NewFromUtf8(isolate, "ObjectID"), Number::New(isolate, pObjData->dwObjectID));
+
 	for (int i = 0; i < numVars; i++)
 	{
 		int varSize = 0;


### PR DESCRIPTION
This patch prepends the simulation object ID to the data object returned by the two calls `requestDataOnSimObject` and `requestDataOnSimObjectType` 

So you/developer/app maker can more easily track a given object as it enters/leaves the scan radius. And see which object in the `requestDataOnSimObjectType` scan radius is the users object.

Patch alters the `handleReceived_Data` function to prepend the ObjectID and some notes to the readme about that.